### PR TITLE
ISSUE-9 - Implement xcodebuild testing action

### DIFF
--- a/swifttesting/README.md
+++ b/swifttesting/README.md
@@ -21,7 +21,7 @@ on:
       - '**.swift'
 
 jobs:
-  swiftlint:
+  swifttesting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/xctesting/README.md
+++ b/xctesting/README.md
@@ -1,0 +1,65 @@
+
+# XCTesting GitHub Action
+
+A GitHub Action that runs XCTesting to ensure tests pass before merging PRs / Deploying (uses xcodebuild).
+
+## Features
+
+- Works on both macos to test xcode testing targets
+- Allows you to specify multiple testing targets at once 
+
+## Usage
+
+Create a workflow file (e.g., `.github/workflows/test-app.yml`) in your repository:
+
+```yaml
+name: Test IOS App
+
+on:
+  pull_request:
+    paths:
+      - '**.swift'
+
+jobs:
+  xctesting:
+    # Highly recommend to use selfhosted mac runners as they are cheaper
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: irgaly/xcode-cache@v1
+        with:
+          key: xcode-cache-deriveddata-${{ github.workflow }}
+          restore-keys: xcode-cache-deriveddata-${{ github.workflow }}
+
+      - name: Run App Tests
+        uses: GetAutomaApp/opensource-actions/xctesting@main
+        with:
+          working-directory: "./App/AppDirectory/"
+          schema: "IOS-ADMIN"
+          destination: "platform=iOS Simulator,name=iPhone 16,OS=18.0"
+          testing-targets: "IOS-ADMINIntegrationTests,IOS-ADMINUnitTests"
+```
+### `working-directory`
+
+Optional. Directory to run XCTesting in. Defaults to repository root ('.').
+
+### Schema
+
+Non-Optional. Xcode Schema you want to run the tests for. `Eg: IOS, IOS-ADMIN`
+
+### Destination
+Non-Optional. On what you want to run tests (Eg: `platform-iOS Simulator,name iPhone 16,OS=18.0`) (Empty string will show all invalid values)
+
+### Testing Targets
+Non-Optional. Comma separated testing targets Eg: IOSUnitTests,IOSUITests
+
+## Outputs
+
+### `exit-code`
+
+The exit code from the SwiftTesting run. 0 indicates success, non-zero indicates issues were found.
+
+## License
+
+MIT

--- a/xctesting/README.md
+++ b/xctesting/README.md
@@ -11,7 +11,6 @@ A GitHub Action that runs XCTesting to ensure tests pass before merging PRs / De
 ## Usage
 
 Create a workflow file (e.g., `.github/workflows/test-app.yml`) in your repository:
-
 ```yaml
 name: Test IOS App
 
@@ -53,12 +52,6 @@ Non-Optional. On what you want to run tests (Eg: `platform-iOS Simulator,name iP
 
 ### Testing Targets
 Non-Optional. Comma separated testing targets Eg: IOSUnitTests,IOSUITests
-
-## Outputs
-
-### `exit-code`
-
-The exit code from the SwiftTesting run. 0 indicates success, non-zero indicates issues were found.
 
 ## License
 

--- a/xctesting/README.md
+++ b/xctesting/README.md
@@ -10,6 +10,10 @@ A GitHub Action that runs XCTesting to ensure tests pass before merging PRs / De
 
 ## Usage
 
+> [!NOTE]
+> We recommend to make use of `macincloud` macos runners instead of github hosted runners. They're way cheaper!!
+> https://portal.macincloud.com/select
+
 Create a workflow file (e.g., `.github/workflows/test-app.yml`) in your repository:
 ```yaml
 name: Test IOS App
@@ -21,8 +25,8 @@ on:
 
 jobs:
   xctesting:
+    runs-on: [macos-latest, self-hosted]
     # Highly recommend to use selfhosted mac runners as they are cheaper
-    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/xctesting/action.yml
+++ b/xctesting/action.yml
@@ -6,7 +6,7 @@ branding:
 
 inputs:
   working-directory:
-    description: "Directory to run `xcodebuild test` in"
+    description: "Directory to run `xcodebuild test` in. Default `.`"
     required: false
     default: "."
   schema:
@@ -28,6 +28,7 @@ runs:
       id: run-tests
       shell: bash
       run: |
+        cd ${{ inputs.working-directory }}
         xcodebuild test \
           -scheme '${{ inputs.schema }}' \
           -destination '${{ inputs.destination }}'

--- a/xctesting/action.yml
+++ b/xctesting/action.yml
@@ -15,6 +15,9 @@ inputs:
   destination:
     description: "String arguments for the `destination` flag"
     required: true
+  testing-targets:
+    description: "Comma separated testing targets Eg: IOSUnitTests,IOSUITests"
+    required: true
 
 outputs:
   exit-code:
@@ -28,7 +31,23 @@ runs:
       id: run-tests
       shell: bash
       run: |
-        cd ${{ inputs.working-directory }}
+        set -e
+
+        cd "${{ inputs.working-directory }}"
+
+        IFS=',' read -ra TARGETS <<< "${{ inputs.testing-targets }}"
+
+        ONLY_TESTING_ARGS=""
+        for TARGET in "${TARGETS[@]}"; do
+          ONLY_TESTING_ARGS="$ONLY_TESTING_ARGS -only-testing:$TARGET"
+        done
+
+        echo "Running tests with targets: ${TARGETS[*]}"
+        echo "xcodebuild test -scheme '${{ inputs.schema }}' -destination '${{ inputs.destination }}' $ONLY_TESTING_ARGS"
+
+        set +e
         xcodebuild test \
-          -scheme '${{ inputs.schema }}' \
-          -destination '${{ inputs.destination }}'
+          -scheme "${{ inputs.schema }}" \
+          -destination "${{ inputs.destination }}" \
+          $ONLY_TESTING_ARGS
+        echo "exit-code=$?" >> $GITHUB_OUTPUT

--- a/xctesting/action.yml
+++ b/xctesting/action.yml
@@ -19,11 +19,6 @@ inputs:
     description: "Comma separated testing targets Eg: IOSUnitTests,IOSUITests"
     required: true
 
-outputs:
-  exit-code:
-    value: ${{ steps.run-tests.outputs.exit-code }}
-    description: "The exit code from the Swift test run"
-
 runs:
   using: "composite"
   steps:
@@ -50,4 +45,9 @@ runs:
           -scheme "${{ inputs.schema }}" \
           -destination "${{ inputs.destination }}" \
           $ONLY_TESTING_ARGS
-        echo "exit-code=$?" >> $GITHUB_OUTPUT
+
+        EXIT_CODE=$?
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "❌ xcodebuild failed with exit code $EXIT_CODE"
+          exit $EXIT_CODE
+        fi

--- a/xctesting/action.yml
+++ b/xctesting/action.yml
@@ -1,0 +1,33 @@
+name: "XCTesting"
+description: "A GitHub Action that runs `xcodebuild test`"
+branding:
+  icon: "code"
+  color: "orange"
+
+inputs:
+  working-directory:
+    description: "Directory to run `xcodebuild test` in"
+    required: false
+    default: "."
+  schema:
+    description: "The schema you want to run tests for"
+    required: true
+  destination:
+    description: "String arguments for the `destination` flag"
+    required: true
+
+outputs:
+  exit-code:
+    value: ${{ steps.run-tests.outputs.exit-code }}
+    description: "The exit code from the Swift test run"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run Tests
+      id: run-tests
+      shell: bash
+      run: |
+        xcodebuild test \
+          -scheme '${{ inputs.schema }}' \
+          -destination '${{ inputs.destination }}'


### PR DESCRIPTION
# Reason

Implements a simple xcodebuild testing action. We want to have an action that can run xcode project tests via github actions to ensure the robustness of any ios based changes.

# Tech Details List

- Implements simple action to run xcode ui / unit test bundles
- Implements simple readme with example workflow file + caching

**Tasks:**
- [ ] Add a quick guide to dotfiles repo on how to setup a selfhosted macos runner + setup script
- [ ] Setup Local runner in UTM (just testing the effectiveness of a virtualized setup (will it work?)
- [ ] Fix up any nits in this PR

**Links:**

[ISSUE-9](https://github.com/GetAutomaApp/AutomaInfraCore/issues/9)
closes #9

# Review Checklist
- [x] Properly Typed All Symbols
- [x] Updated All documentation that the code touched
- [x] Testing Fresh Deployment works with a singular command
- [x] Tests cover all discovered edge cases
- [x] Handles all errors gracefully, ensuring unexpected errors are tracked & monitored
- [x] Code Structure Correctness
- [x] Cleanup of temporary/noise/testing files
- [x] Load Testing: Ensure the code handles expected traffic efficiently
